### PR TITLE
Fix P2P audio recording

### DIFF
--- a/raspberry-pi/src/types/node-record-lpcm16.d.ts
+++ b/raspberry-pi/src/types/node-record-lpcm16.d.ts
@@ -1,5 +1,6 @@
 declare module "node-record-lpcm16" {
-  import { EventEmitter } from "events";
+  import { Readable } from "stream";
+
   interface RecordOptions {
     sampleRate?: number;
     channels?: number;
@@ -12,10 +13,19 @@ declare module "node-record-lpcm16" {
     audioType?: string;
     verbose?: boolean;
   }
-  interface Record {
-    start(options?: RecordOptions): EventEmitter;
+
+  interface Recording {
     stop(): void;
+    pause(): void;
+    resume(): void;
+    isPaused(): boolean;
+    stream(): Readable;
   }
-  const record: Record;
-  export = record;
+
+  interface Recorder {
+    record(options?: RecordOptions): Recording;
+  }
+
+  const recorder: Recorder;
+  export = recorder;
 }


### PR DESCRIPTION
## Summary
- update `node-record-lpcm16` typings to match library API
- use `record.record()` in the raspberry pi client
- stop recording when the peer connection closes

## Testing
- `yarn --cwd backend test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856271e018c8324bdf9a00e7b55ace1